### PR TITLE
Added T_Muon_fromPV, T_Muon_IsHighPurityTrack, T_Muon_IsTightMuon.

### DIFF
--- a/TopTreeProducer/src/SUSYSkimToTreeTFS.cc
+++ b/TopTreeProducer/src/SUSYSkimToTreeTFS.cc
@@ -318,38 +318,60 @@ private:
   std::vector<float> *T_Gen_Tau_LepDec_Energy;
  
   //Muons
-  std::vector<float>*T_Muon_Eta;
-  std::vector<bool> *T_Muon_IsGlobalMuon;
-  std::vector<bool> *T_Muon_IsGMPTMuons;
-  std::vector<bool> *T_Muon_IsAllStandAloneMuons;
-  std::vector<bool> *T_Muon_IsTMLastStationTight;       // penetration depth Tight selector
-  std::vector<bool> *T_Muon_IsAllTrackerMuons;          // checks isTrackerMuon flag
-  std::vector<bool> *T_Muon_IsTrackerMuonArbitrated;    // resolve ambiguity of sharing segments
-  std::vector<bool> *T_Muon_IsAllArbitrated;            // all muons with the tracker muon arbitrated
-  std::vector<float> *T_Muon_SegmentCompatibility; 
-  std::vector<float> *T_Muon_trkKink;
-  std::vector<float> *T_Muon_StaTrkMatchChi2;            // Chi2 of matching STA-TK tracks
+  //ID
+  std::vector<bool>  *T_Muon_IsGlobalMuon;
+  std::vector<bool>  *T_Muon_isPFMuon;
+  std::vector<bool>  *T_Muon_isTightMuon;
+  std::vector<bool>  *T_Muon_IsGMPTMuons;
+  std::vector<bool>  *T_Muon_IsAllStandAloneMuons;
+  std::vector<bool>  *T_Muon_IsTMLastStationTight;       // penetration depth Tight selector
+  std::vector<bool>  *T_Muon_IsAllTrackerMuons;          // checks isTrackerMuon flag
+  std::vector<bool>  *T_Muon_IsTrackerMuonArbitrated;    // resolve ambiguity of sharing segments
+  std::vector<bool>  *T_Muon_IsAllArbitrated;            // all muons with the tracker muon arbitrate
+  std::vector<bool>  *T_Muon_IsHighPurityTrack;
+  //Kinematic
+  std::vector<float> *T_Muon_Eta;  
   std::vector<float> *T_Muon_Px;
   std::vector<float> *T_Muon_Py;
   std::vector<float> *T_Muon_Pz;
   std::vector<float> *T_Muon_Pt;
+  std::vector<float> *T_Muon_BestTrack_Px;
+  std::vector<float> *T_Muon_BestTrack_Py;
+  std::vector<float> *T_Muon_BestTrack_Pz;
+  std::vector<float> *T_Muon_BestTrack_Pt;
+  std::vector<float> *T_Muon_BestTrack_Phi;
   std::vector<float> *T_Muon_deltaPt;
   std::vector<float> *T_Muon_Energy;
-  std::vector<int> *T_Muon_Charge;
+  std::vector<int>   *T_Muon_Charge;
+  //Track info
+  std::vector<float> *T_Muon_vz;
+  std::vector<float> *T_Muon_vy;
+  std::vector<float> *T_Muon_vx;
+  std::vector<float> *T_Muon_BestTrack_vx;
+  std::vector<float> *T_Muon_BestTrack_vy;
+  std::vector<float> *T_Muon_BestTrack_vz;
   std::vector<float> *T_Muon_NormChi2GTrk;
-  std::vector<int> *T_Muon_NValidHitsInTrk;
-  std::vector<int> *T_Muon_NValidPixelHitsInTrk;
-  std::vector<int> *T_Muon_NValidHitsSATrk;
-  std::vector<int> *T_Muon_NValidHitsGTrk;
-  std::vector<int> *T_Muon_NumOfMatchedStations;
-  std::vector<int> *T_Muon_InnerTrackFound;
   std::vector<float> *T_Muon_Chi2InTrk;
+  std::vector<float> *T_Muon_StaTrkMatchChi2;            // Chi2 of matching STA-TK tracks
   std::vector<float> *T_Muon_dofInTrk;
+  std::vector<int>   *T_Muon_NValidHitsInTrk;
+  std::vector<int>   *T_Muon_NValidPixelHitsInTrk;
+  std::vector<int>   *T_Muon_NValidHitsSATrk;
+  std::vector<int>   *T_Muon_NValidHitsGTrk;
+  std::vector<int>   *T_Muon_NLayers;
+  std::vector<int>   *T_Muon_InnerTrackFound;
+  std::vector<int>   *T_Muon_NumOfMatchedStations;
+  std::vector<float> *T_Muon_SegmentCompatibility; 
+  std::vector<float> *T_Muon_trkKink;
   std::vector<float> *T_Muon_dxyGTrack;
   std::vector<float> *T_Muon_dxyInTrack;
   std::vector<float> *T_Muon_dzGTrack;
   std::vector<float> *T_Muon_dzInTrack;
-  std::vector<float> *T_Muon_IPwrtAveBSInTrack;
+  std::vector<float> *T_Muon_IPwrtAveBSInTrack;         // dxy w.r.t Beam Spot
+  std::vector<float> *T_Muon_BestTrack_dxy;
+  std::vector<float> *T_Muon_BestTrack_dz;
+  std::vector<int>   *T_Muon_fromPV;                    // Association to the first PV. 3:PVUsedInFit, 2:PVTight, 1:PVLoose, 0:NoPV
+  //Isolation
   std::vector<float> *T_Muon_chargedHadronIsoR04;
   std::vector<float> *T_Muon_neutralHadronIsoR04;
   std::vector<float> *T_Muon_neutralIsoPFweightR04;
@@ -361,21 +383,6 @@ private:
   std::vector<float> *T_Muon_neutralIsoPFweightR03;
   std::vector<float> *T_Muon_photonIsoR03;
   std::vector<float> *T_Muon_sumPUPtR03;
-  std::vector<float> *T_Muon_vz;
-  std::vector<float> *T_Muon_vy;
-  std::vector<float> *T_Muon_vx;
-  std::vector<bool> *T_Muon_isPFMuon;
-  std::vector<int> *T_Muon_NLayers;
-  std::vector<float> *T_Muon_BestTrack_dxy;
-  std::vector<float> *T_Muon_BestTrack_dz;
-  std::vector<float> *T_Muon_BestTrack_vx;
-  std::vector<float> *T_Muon_BestTrack_vy;
-  std::vector<float> *T_Muon_BestTrack_vz;
-  std::vector<float> *T_Muon_BestTrack_Px;
-  std::vector<float> *T_Muon_BestTrack_Py;
-  std::vector<float> *T_Muon_BestTrack_Pz;
-  std::vector<float> *T_Muon_BestTrack_Pt;
-  std::vector<float> *T_Muon_BestTrack_Phi;
 
   // Tau
   /*  std::vector<float> *T_Tau_Px;
@@ -502,7 +509,9 @@ private:
   float T_METgen_Phi;
   
   //HLT
-   bool T_HLT_Mu_vx;
+  bool T_HLT_Mu_vx;
+  
+  int fromPV_Count = 1;
 };
 
 //
@@ -1351,6 +1360,7 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   T_Muon_vy = new std::vector<float>;  
   T_Muon_vx = new std::vector<float>;
   T_Muon_isPFMuon = new std::vector<bool>;
+  T_Muon_isTightMuon = new std::vector<bool>;
   T_Muon_NLayers =  new std::vector<int>;
   T_Muon_BestTrack_dxy = new std::vector<float>;
   T_Muon_BestTrack_dz  = new std::vector<float>;
@@ -1362,6 +1372,8 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   T_Muon_BestTrack_Pz  = new std::vector<float>;
   T_Muon_BestTrack_Pt  = new std::vector<float>;
   T_Muon_BestTrack_Phi = new std::vector<float>;
+  T_Muon_fromPV = new std::vector<int>;
+  T_Muon_IsHighPurityTrack = new std::vector<bool>;
 
   //Muons
   //no estoy seguro de que haga falta ordenar (se puede usar para filtrar en el futuro)
@@ -1452,6 +1464,8 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     T_Muon_Eta->push_back(selected_muons[k].eta()); 
     
     T_Muon_IsGlobalMuon->push_back(selected_muons[k].isGlobalMuon());
+    T_Muon_isPFMuon->push_back(selected_muons[k].isPFMuon());
+    if (vtxs.size() > 0) T_Muon_isTightMuon->push_back(selected_muons[k].isTightMuon(vtxs[0]));
     T_Muon_IsGMPTMuons->push_back(selected_muons[k].muonID("GlobalMuonPromptTight"));
     T_Muon_IsAllTrackerMuons->push_back(selected_muons[k].muonID("AllTrackerMuons"));
     T_Muon_IsTrackerMuonArbitrated->push_back(selected_muons[k].muonID("TrackerMuonArbitrated"));
@@ -1495,8 +1509,8 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
     T_Muon_StaTrkMatchChi2->push_back(selected_muons[k].combinedQuality().staRelChi2);
     T_Muon_NValidHitsSATrk->push_back(nhitsouttrack);
     T_Muon_NumOfMatchedStations->push_back(selected_muons[k].numberOfMatchedStations());
-    T_Muon_isPFMuon->push_back(selected_muons[k].isPFMuon ());
     T_Muon_NLayers->push_back(nLayers);
+    //T_Muon_fromPV->push_back(selected_muons[k].sourceCandidatePtr(0).fromPV());
 
 
     //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PF-Reweight ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1517,6 +1531,8 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       
       // PF candidate-based footprint removal
       if (std::find(footprint.begin(), footprint.end(), reco::CandidatePtr(pfHandle,i)) != footprint.end()) {
+	T_Muon_fromPV->push_back(pf.fromPV());
+	T_Muon_IsHighPurityTrack->push_back(pf.trackHighPurity());
 	continue;
       }
 
@@ -1582,6 +1598,7 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 
     T_Muon_neutralIsoPFweightR03->push_back(muon_neutralIsoPFweightR03);
     T_Muon_neutralIsoPFweightR04->push_back(muon_neutralIsoPFweightR04);
+
   }
   
   
@@ -2059,6 +2076,7 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   delete T_Muon_sumPUPtR04;
   delete T_Muon_sumPUPtR03;
   delete T_Muon_isPFMuon;
+  delete T_Muon_isTightMuon;
   delete T_Muon_NLayers;
   delete T_Muon_BestTrack_dxy;
   delete T_Muon_BestTrack_dz;
@@ -2070,6 +2088,8 @@ SUSYSkimToTreeTFS::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
   delete T_Muon_BestTrack_Pz;
   delete T_Muon_BestTrack_Pt;
   delete T_Muon_BestTrack_Phi;
+  delete T_Muon_fromPV;
+  delete T_Muon_IsHighPurityTrack;
 
   //Electrons
   delete T_Elec_Eta;
@@ -2704,65 +2724,70 @@ SUSYSkimToTreeTFS::beginJob()
 
    
   //Muons
-  Tree->Branch("T_Muon_Eta", "std::vector<float>", &T_Muon_Eta);
   Tree->Branch("T_Muon_IsGlobalMuon", "std::vector<bool>", &T_Muon_IsGlobalMuon);
+  Tree->Branch("T_Muon_isPFMuon","std::vector<bool>", &T_Muon_isPFMuon);
+  Tree->Branch("T_Muon_isTightMuon","std::vector<bool>", &T_Muon_isTightMuon);
   Tree->Branch("T_Muon_IsAllTrackerMuons", "std::vector<bool>", &T_Muon_IsAllTrackerMuons);
   Tree->Branch("T_Muon_IsTrackerMuonArbitrated", "std::vector<bool>", &T_Muon_IsTrackerMuonArbitrated);
+  Tree->Branch("T_Muon_IsAllArbitrated", "std::vector<bool>", &T_Muon_IsAllArbitrated);
   Tree->Branch("T_Muon_IsGMPTMuons", "std::vector<bool>", &T_Muon_IsGMPTMuons);
   Tree->Branch("T_Muon_IsAllStandAloneMuons", "std::vector<bool>", &T_Muon_IsAllStandAloneMuons);
   Tree->Branch("T_Muon_IsTMLastStationTight", "std::vector<bool>", &T_Muon_IsTMLastStationTight);
+  Tree->Branch("T_Muon_IsHighPurityTrack", "std::vector<bool>", &T_Muon_IsHighPurityTrack);
  
-  Tree->Branch("T_Muon_SegmentCompatibility","std::vector<float>", &T_Muon_SegmentCompatibility);
-  Tree->Branch("T_Muon_trkKink","std::vector<float>", &T_Muon_trkKink);
-  Tree->Branch("T_Muon_StaTrkMatchChi2","std::vector<float>", &T_Muon_StaTrkMatchChi2);
+  Tree->Branch("T_Muon_Eta", "std::vector<float>", &T_Muon_Eta);
   Tree->Branch("T_Muon_Px", "std::vector<float>", &T_Muon_Px);
   Tree->Branch("T_Muon_Py", "std::vector<float>", &T_Muon_Py);
   Tree->Branch("T_Muon_Pz", "std::vector<float>", &T_Muon_Pz);
   Tree->Branch("T_Muon_Pt", "std::vector<float>", &T_Muon_Pt);
-  Tree->Branch("T_Muon_deltaPt", "std::vector<float>", &T_Muon_deltaPt);
-  Tree->Branch("T_Muon_Energy", "std::vector<float>", &T_Muon_Energy);
-  Tree->Branch("T_Muon_Charge", "std::vector<int>", &T_Muon_Charge);
-  Tree->Branch("T_Muon_NormChi2GTrk", "std::vector<float>", &T_Muon_NormChi2GTrk);
-  Tree->Branch("T_Muon_NValidHitsInTrk", "std::vector<int>", &T_Muon_NValidHitsInTrk);
-  Tree->Branch("T_Muon_NValidPixelHitsInTrk", "std::vector<int>", &T_Muon_NValidPixelHitsInTrk);
-  Tree->Branch("T_Muon_InnerTrackFound", "std::vector<int>", &T_Muon_InnerTrackFound);
-  Tree->Branch("T_Muon_NValidHitsSATrk", "std::vector<int>", &T_Muon_NValidHitsSATrk);
-  Tree->Branch("T_Muon_NValidHitsGTrk", "std::vector<int>", &T_Muon_NValidHitsGTrk);
-  Tree->Branch("T_Muon_Chi2InTrk", "std::vector<float>", &T_Muon_Chi2InTrk);
-  Tree->Branch("T_Muon_dofInTrk", "std::vector<float>", &T_Muon_dofInTrk);
-  Tree->Branch("T_Muon_dxyGTrack", "std::vector<float>", &T_Muon_dxyGTrack);
-  Tree->Branch("T_Muon_dxyInTrack", "std::vector<float>", &T_Muon_dxyInTrack);
-  Tree->Branch("T_Muon_dzGTrack", "std::vector<float>", &T_Muon_dzGTrack);
-  Tree->Branch("T_Muon_dzInTrack", "std::vector<float>", &T_Muon_dzInTrack);
-  Tree->Branch("T_Muon_IPwrtAveBSInTrack", "std::vector<float>", &T_Muon_IPwrtAveBSInTrack);
-
-  Tree->Branch("T_Muon_chargedHadronIsoR04", "std::vector<float>", &T_Muon_chargedHadronIsoR04);
-  Tree->Branch("T_Muon_neutralHadronIsoR04", "std::vector<float>", &T_Muon_neutralHadronIsoR04);
-  Tree->Branch("T_Muon_neutralIsoPFweightR04", "std::vector<float>", &T_Muon_neutralIsoPFweightR04);
-  Tree->Branch("T_Muon_photonIsoR04", "std::vector<float>", &T_Muon_photonIsoR04);
-  Tree->Branch("T_Muon_chargedParticleIsoR03", "std::vector<float>", &T_Muon_chargedParticleIsoR03);
-  Tree->Branch("T_Muon_chargedHadronIsoR03", "std::vector<float>", &T_Muon_chargedHadronIsoR03);
-  Tree->Branch("T_Muon_neutralHadronIsoR03", "std::vector<float>", &T_Muon_neutralHadronIsoR03);
-  Tree->Branch("T_Muon_neutralIsoPFweightR03", "std::vector<float>", &T_Muon_neutralIsoPFweightR03);
-  Tree->Branch("T_Muon_photonIsoR03", "std::vector<float>", &T_Muon_photonIsoR03);
-  Tree->Branch("T_Muon_sumPUPtR04", "std::vector<float>", &T_Muon_sumPUPtR04);
-  Tree->Branch("T_Muon_sumPUPtR03", "std::vector<float>", &T_Muon_sumPUPtR03);
-  Tree->Branch("T_Muon_vz", "std::vector<float>", &T_Muon_vz);
-  Tree->Branch("T_Muon_vy", "std::vector<float>", &T_Muon_vy);
-  Tree->Branch("T_Muon_vx", "std::vector<float>", &T_Muon_vx);
-  Tree->Branch("T_Muon_NumOfMatchedStations", "std::vector<int>", &T_Muon_NumOfMatchedStations);
-  Tree->Branch("T_Muon_isPFMuon","std::vector<bool>", &T_Muon_isPFMuon);
-  Tree->Branch("T_Muon_NLayers","std::vector<int>", &T_Muon_NLayers);
-  Tree->Branch("T_Muon_BestTrack_dxy", "std::vector<float>", &T_Muon_BestTrack_dxy);
-  Tree->Branch("T_Muon_BestTrack_dz",  "std::vector<float>", &T_Muon_BestTrack_dz);
-  Tree->Branch("T_Muon_BestTrack_vx",  "std::vector<float>", &T_Muon_BestTrack_vx);
-  Tree->Branch("T_Muon_BestTrack_vy",  "std::vector<float>", &T_Muon_BestTrack_vy);
-  Tree->Branch("T_Muon_BestTrack_vz",  "std::vector<float>", &T_Muon_BestTrack_vz);
   Tree->Branch("T_Muon_BestTrack_Px",  "std::vector<float>", &T_Muon_BestTrack_Px);
   Tree->Branch("T_Muon_BestTrack_Py",  "std::vector<float>", &T_Muon_BestTrack_Py);
   Tree->Branch("T_Muon_BestTrack_Pz",  "std::vector<float>", &T_Muon_BestTrack_Pz);
   Tree->Branch("T_Muon_BestTrack_Pt",  "std::vector<float>", &T_Muon_BestTrack_Pt);
   Tree->Branch("T_Muon_BestTrack_Phi", "std::vector<float>", &T_Muon_BestTrack_Phi);
+  Tree->Branch("T_Muon_deltaPt", "std::vector<float>", &T_Muon_deltaPt);
+  Tree->Branch("T_Muon_Energy", "std::vector<float>", &T_Muon_Energy);
+  Tree->Branch("T_Muon_Charge", "std::vector<int>", &T_Muon_Charge);
+
+  Tree->Branch("T_Muon_vz", "std::vector<float>", &T_Muon_vz);
+  Tree->Branch("T_Muon_vy", "std::vector<float>", &T_Muon_vy);
+  Tree->Branch("T_Muon_vx", "std::vector<float>", &T_Muon_vx);
+  Tree->Branch("T_Muon_BestTrack_vx",  "std::vector<float>", &T_Muon_BestTrack_vx);
+  Tree->Branch("T_Muon_BestTrack_vy",  "std::vector<float>", &T_Muon_BestTrack_vy);
+  Tree->Branch("T_Muon_BestTrack_vz",  "std::vector<float>", &T_Muon_BestTrack_vz);
+  Tree->Branch("T_Muon_NormChi2GTrk", "std::vector<float>", &T_Muon_NormChi2GTrk);
+  Tree->Branch("T_Muon_Chi2InTrk", "std::vector<float>", &T_Muon_Chi2InTrk);
+  Tree->Branch("T_Muon_StaTrkMatchChi2","std::vector<float>", &T_Muon_StaTrkMatchChi2);
+  Tree->Branch("T_Muon_dofInTrk", "std::vector<float>", &T_Muon_dofInTrk);
+  Tree->Branch("T_Muon_NValidHitsInTrk", "std::vector<int>", &T_Muon_NValidHitsInTrk);
+  Tree->Branch("T_Muon_NValidPixelHitsInTrk", "std::vector<int>", &T_Muon_NValidPixelHitsInTrk);
+  Tree->Branch("T_Muon_NValidHitsSATrk", "std::vector<int>", &T_Muon_NValidHitsSATrk);
+  Tree->Branch("T_Muon_NValidHitsGTrk", "std::vector<int>", &T_Muon_NValidHitsGTrk);
+  Tree->Branch("T_Muon_NLayers","std::vector<int>", &T_Muon_NLayers);
+  Tree->Branch("T_Muon_InnerTrackFound", "std::vector<int>", &T_Muon_InnerTrackFound);
+  Tree->Branch("T_Muon_NumOfMatchedStations", "std::vector<int>", &T_Muon_NumOfMatchedStations);
+  Tree->Branch("T_Muon_SegmentCompatibility","std::vector<float>", &T_Muon_SegmentCompatibility);
+  Tree->Branch("T_Muon_trkKink","std::vector<float>", &T_Muon_trkKink);
+  Tree->Branch("T_Muon_dxyGTrack", "std::vector<float>", &T_Muon_dxyGTrack);
+  Tree->Branch("T_Muon_dxyInTrack", "std::vector<float>", &T_Muon_dxyInTrack);
+  Tree->Branch("T_Muon_BestTrack_dxy", "std::vector<float>", &T_Muon_BestTrack_dxy);
+  Tree->Branch("T_Muon_IPwrtAveBSInTrack", "std::vector<float>", &T_Muon_IPwrtAveBSInTrack);
+  Tree->Branch("T_Muon_dzGTrack", "std::vector<float>", &T_Muon_dzGTrack);
+  Tree->Branch("T_Muon_dzInTrack", "std::vector<float>", &T_Muon_dzInTrack);
+  Tree->Branch("T_Muon_BestTrack_dz",  "std::vector<float>", &T_Muon_BestTrack_dz);
+  Tree->Branch("T_Muon_fromPV", "std::vector<int>", &T_Muon_fromPV);
+
+  Tree->Branch("T_Muon_chargedHadronIsoR04", "std::vector<float>", &T_Muon_chargedHadronIsoR04);
+  Tree->Branch("T_Muon_neutralHadronIsoR04", "std::vector<float>", &T_Muon_neutralHadronIsoR04);
+  Tree->Branch("T_Muon_neutralIsoPFweightR04", "std::vector<float>", &T_Muon_neutralIsoPFweightR04);
+  Tree->Branch("T_Muon_photonIsoR04", "std::vector<float>", &T_Muon_photonIsoR04);
+  Tree->Branch("T_Muon_sumPUPtR04", "std::vector<float>", &T_Muon_sumPUPtR04);
+  Tree->Branch("T_Muon_chargedParticleIsoR03", "std::vector<float>", &T_Muon_chargedParticleIsoR03);
+  Tree->Branch("T_Muon_chargedHadronIsoR03", "std::vector<float>", &T_Muon_chargedHadronIsoR03);
+  Tree->Branch("T_Muon_neutralHadronIsoR03", "std::vector<float>", &T_Muon_neutralHadronIsoR03);
+  Tree->Branch("T_Muon_neutralIsoPFweightR03", "std::vector<float>", &T_Muon_neutralIsoPFweightR03);
+  Tree->Branch("T_Muon_photonIsoR03", "std::vector<float>", &T_Muon_photonIsoR03);
+  Tree->Branch("T_Muon_sumPUPtR03", "std::vector<float>", &T_Muon_sumPUPtR03);
 
   //Taus
   /*  Tree->Branch("T_Tau_Px", "std::vector<float>", &T_Tau_Px);


### PR DESCRIPTION
Also added some documentation and sorted muon branches. 

T_Muon_fromPV: returns a number between 3 and 0 to define how tight the association with the first PV is: the tighest, 3 (PVUsedInFit), is if the track is used in the first PV fit; 2 (PVTight) is if the track is not used in the fit of any of the PVs, and is closest in z to the first PV, while 1 (PVLoose) is if the track is closest in z to a PV other then the first one. 0 (NoPV) is returned if the track is used in the fit of another PV.
